### PR TITLE
add encoding for python 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 import os
+import sys
 
 from distutils.core import Extension
 
@@ -9,11 +10,16 @@ extLevensthein = Extension('Levenshtein',
                            sources = ['Levenshtein.c'],
                            )
 
+if sys.version_info >= (3, 0):
+    _open = lambda f: open(f, encoding='utf8')
+else:
+    _open = open
+
 setup(name='python-Levenshtein',
       version=version,
       description="Python extension for computing string edit distances and similarities.",
-      long_description=open("README.rst").read() + "\n" +
-                       open(os.path.join("HISTORY.txt")).read(),
+      long_description=_open("README.rst").read() + "\n" +
+                       _open(os.path.join("HISTORY.txt")).read(),
       # Get more strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",


### PR DESCRIPTION
Installation with python 3.x will fail if command line encoding is not utf-8:

```
$ LANG=C python setup.py build
Traceback (most recent call last):
  File "setup.py", line 15, in <module>
    long_description=open("README.rst").read() + "\n" +
  File "/usr/lib/python3.3/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1968: ordinal not in range(128)
```

This patch forced encoding to utf-8 if using python 3.x to install. Tried with python 2.7.6 and 3.3.3 and it works well.
