### PR TITLE
Added pip install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,13 @@ are provided yet, RTFS.  But they are not interchangeable:
 * Unicode character type used with -DNO_PYTHON is wchar_t, Python extension
   uses Py_UNICODE, they may be the same but don't count on it
 
+Installation
+------------
+
+::
+
+   pip install python-Levenshtein
+
 Documentation
 --------------
 


### PR DESCRIPTION
I added some `pip install` instructions to the README. 
While the github repo name and the pip package name match, that can't always be assumed. This saves the step of searching PyPI for the right package. 