### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 
 # command to install dependencies
 install: "python setup.py develop"

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,13 @@ are provided yet, RTFS.  But they are not interchangeable:
 * Unicode character type used with -DNO_PYTHON is wchar_t, Python extension
   uses Py_UNICODE, they may be the same but don't count on it
 
+Installation
+------------
+
+::
+
+   pip install python-Levenshtein
+
 Documentation
 --------------
 


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.


Pls verify and merge
